### PR TITLE
Implement singleton speech service to replace new utterance creation …

### DIFF
--- a/app/game/listen/_components/Mcq.tsx
+++ b/app/game/listen/_components/Mcq.tsx
@@ -6,6 +6,8 @@ import { PromptType, TermItem } from "@/types/game";
 import { ChoiceBox } from "../../mcq/_components/choice-box";
 import { Button } from "@/components/ui/button";
 
+import { SpeechService } from "@/lib/speech";
+
 interface McqProps {
   question: TermItem;
   choices: TermItem[];
@@ -13,7 +15,6 @@ interface McqProps {
   handleSubmit: () => void;
   formSubmitted: boolean;
   updateScore: () => void;
-  speakWord: (word: string) => void;
 }
 
 export const Mcq = ({
@@ -23,7 +24,6 @@ export const Mcq = ({
   handleSubmit,
   formSubmitted,
   updateScore,
-  speakWord,
 }: McqProps) => {
   const [selectedChoice, setSelectedChoice] = useState<number | null>(null);
 
@@ -62,16 +62,15 @@ export const Mcq = ({
             Choose the correct <span className="font-medium underline underline-offset-2">term/definition</span>
           </div>
           <div>
-            <Button onClick={() => speakWord("The term is:"+question.term)}>Listen to the term</Button>
+            <Button onClick={() => SpeechService.speak("The term is:" + question.term)}>Listen to the term</Button>
             {choiceType === PromptType.DEF && (
               <Button onClick={() => {
-                  speakWord("The choices are: ");
+                  SpeechService.cancel();
+                  SpeechService.speakSequence(["The choices are: "]);
                   choices.forEach((choice, index) => {
-                  const label = String.fromCharCode(65 + index);
-                  //seperated so there is a pause
-                  speakWord(`${label}.`);
-                  speakWord(`${choice.definition}`);
-                });
+                    const label = String.fromCharCode(65 + index);
+                    SpeechService.speakSequence([`${label}.`, `${choice.definition}`]);
+                  });
               }}>Listen to the choices</Button>
             )}
           </div>

--- a/app/game/listen/page.tsx
+++ b/app/game/listen/page.tsx
@@ -14,6 +14,7 @@ import NextButton from "../_components/next-button";
 
 import { cn, getOneRandom, shuffle } from "@/lib/utils";
 import { PromptType } from "@/types/game";
+import { SpeechService } from "@/lib/speech";
 
 const TIME_LIMIT = 10; // in seconds
 
@@ -31,12 +32,6 @@ const ListeningGame: React.FC = () => {
   const [score, setScore] = useState(0);
 
   const { isLoading } = useUserData();
-
-  const speakWord = (word: string) => {
-    const utterance = new SpeechSynthesisUtterance(word);
-    utterance.rate = 0.7;
-    speechSynthesis.speak(utterance);
-  };
 
   const getRandomPromptType = () => {
     return Math.random() > 0.5 ? PromptType.TERM : PromptType.DEF;
@@ -79,6 +74,8 @@ const ListeningGame: React.FC = () => {
   };
 
   const handleNext = () => {
+    SpeechService.cancel();  // Clear speech utterance queue before going to the next round
+
     if (availableQuestions.length === 0) {
       // if no more questions, stop the game
       // to mark no more questions left
@@ -195,7 +192,6 @@ const ListeningGame: React.FC = () => {
                 handleSubmit={handleSubmit}
                 formSubmitted={formSubmitted}
                 updateScore={() => setScore(score + 1)}
-                speakWord={speakWord} // Pass speakWord function to Mcq component
               />
             </motion.div>
           ) : (

--- a/lib/speech.ts
+++ b/lib/speech.ts
@@ -1,0 +1,51 @@
+class SpeechSingleton {
+  private static instance: SpeechSingleton;
+  private utterance: SpeechSynthesisUtterance;
+  private isSpeakingQueue: boolean = false;
+  private queue: string[] = [];
+
+  private constructor() {
+    this.utterance = new SpeechSynthesisUtterance();
+    this.utterance.rate = 0.7
+    this.utterance.onend = () => {
+      this.isSpeakingQueue = false;
+      this.processQueue();
+    };
+  }
+
+  static getInstance(): SpeechSingleton {
+    if (!SpeechSingleton.instance) {
+      SpeechSingleton.instance = new SpeechSingleton();
+    }
+    return SpeechSingleton.instance;
+  }
+
+  speak(text: string) {
+    this.cancel();
+    this.utterance.text = text;
+    speechSynthesis.speak(this.utterance);
+  }
+
+  speakSequence(texts: string[]) {
+    this.queue.push(...texts);
+    if (!this.isSpeakingQueue) {
+      this.processQueue();
+    }
+  }
+
+  private processQueue() {
+    if (this.queue.length > 0 && !this.isSpeakingQueue) {
+      this.isSpeakingQueue = true;
+      this.utterance.text = this.queue.shift()!;
+      speechSynthesis.speak(this.utterance);
+    }
+  }
+
+  cancel() {
+    speechSynthesis.cancel();
+    this.isSpeakingQueue = false;
+    this.queue = [];
+  }
+}
+
+export const SpeechService = SpeechSingleton.getInstance();


### PR DESCRIPTION
1. Removed logic that created a new utterance instance for every click of listen
2. Replaced with a singleton speech service with exposed methods for speaking and cancelling
- what works: speech gets reset every time a listen button is clicked or when moving to the next round